### PR TITLE
Removes ParameterizedQuery usage

### DIFF
--- a/public/comt_datasets.json
+++ b/public/comt_datasets.json
@@ -1,5 +1,5 @@
 {
-    "dataset": [
+    "datasets": [
         {
             "references": [], 
             "description": null, 

--- a/public/variables.json
+++ b/public/variables.json
@@ -1,68 +1,260 @@
 {
     "variables": [
-        [            "time_of_maximum_wind", "#000000"        ], 
-        [            "ocean_sigma/general_coordinate", "#000000"        ], 
-        [            "radiation_stress_gradient_y",     "#000000"        ], 
-        [            "radiation_stress_gradient_x",             "#000000"        ], 
-        [            "pressure_gradient_x",             "#000000"        ], 
-        [            "water_surface_height_above_reference_datum",             "#d9534f"        ], 
-        [            "maximum_sea_surface_wave_period_at_variance_spectral_density_maximum",             "#5cb85c"        ], 
-        [            "ocean_s_coordinate_g2",             "#000000"        ], 
-        [            "sea_surface_wave_period_at_variance_spectral_density_maximum",             "#5cb85c"        ], 
-        [            "sea_surface_wave_significant_height",             "#5cb85c"        ], 
-        [            "mass_concentration_of_oxygen_in_sea_water",             "#428bca"        ], 
-        [            "wind_speed_y",             "#ecc376"        ], 
-        [            "wind_speed_x",             "#ecc376"        ], 
-        [            "sea_floor_depth_below_geoid",             "#d9534f"        ], 
-        [            "maximum_radiation_stress",             "#000000"        ], 
-        [            "eastward_wind",             "#ecc376"        ], 
-        [            "significant_wave_height",             "#5cb85c"        ], 
-        [            "sea_surface_wave_to_direction",             "#5cb85c"        ], 
-        [            "maximum_wind",             "#ecc376"        ], 
-        [            "maximum_water_velocity",             "#d9534f"        ], 
-        [            "dissolve oxygen",             "#428bca"        ], 
-        [            "minimum_air_pressure_at_sea_level",            "#ecc376"        ], 
-        [            "air_pressure_at_sea_level",             "#ecc376"        ], 
-        [            "time_of_maximum_sea_surface_height_above_geoid",             "#000000"        ], 
-        [            "peak_period",             "#5cb85c"        ], 
-        [            "sea_water_salinity",             "#428bca"        ], 
-        [            "eastward_sea_water_velocity",             "#d9534f"        ], 
-        [            "latitude",             "#000000"        ], 
-        [            "sediment oxygen sonsumption",             "#428bca"        ], 
-        [            "sea_surface_wave_mean_period_from_variance_spectral_density_inverse_frequency_moment",             "#5cb85c"        ], 
-        [            "depth below geoid",             "#d9534f"        ], 
-        [            "time_of_maximum_radiation_stress",             "#000000"        ], 
-        [            "pressure_gradient_y",             "#000000"        ], 
-        [            "northward_wind",             "#ecc376"        ], 
-        [            "northward_water_velocity",             "#d9534f"        ], 
-        [            "sea_water_potential_temperature",             "#428bca"        ], 
-        [            "time",             "#000000"        ], 
-        [            "mesh_topology",             "#000000"        ], 
-        [            "sea_surface_wave_mean_period_from_variance_spectral_density_second_frequency_moment",             "#5cb85c"        ], 
-        [            "ocean_s_coordinate_g1",             "#000000"        ], 
-        [            "ocean_sigma_coordinate",             "#000000"        ], 
-        [            "northward_sea_water_velocity",             "#d9534f"        ], 
-        [            "face_node_connectivity",             "#000000"        ], 
-        [            "Wind Velocity",             "#ecc376"        ], 
-        [            "maximum_sea_surface_wave_to_direction",             "#5cb85c"        ], 
-        [            "wind_stress_y",             "#000000"        ],
-        [            "wind_stress_x",             "#000000"        ], 
-        [            "eastward_water_velocity",             "#d9534f"        ], 
-        [            "maximum_sea_surface_wave_significant_height",             "#5cb85c"        ], 
-        [            "time_of_maximum_water_velocity",             "#000000"        ], 
-        [            "wave_direction",             "#5cb85c"        ], 
-        [            "sea_surface_elevation",             "#d9534f"        ], 
-        [            "maximum_sea_surface_height_above_geoid",             "#d9534f"        ], 
-        [            "depth_below_geoid",             "#d9534f"        ], 
-        [            "longitude",             "#000000"        ], 
-        [            "time_of_minimum_air_pressure_at_sea_level",             "#000000"        ], 
-        [            "mean_period",             "#5cb85c"        ], 
-        [            "sea_surface_height_above_geoid",             "#d9534f"        ], 
-        [            "sea_surface_temperature",             "#428bca"        ], 
-        [            "maximum_sea_surface_wave_mean_period_from_variance_spectral_density_inverse_frequency_moment",             "#5cb85c"        ], 
-        [            "sea_surface_salinity",             "#428bca"        ], 
-        [            "maximum_sea_surface_wave_mean_period_from_variance_spectral_density_second_frequency_moment",             "#5cb85c"        ], 
-        [            "sea_water_temperature",             "#428bca"        ], 
-        [            "net water column oxygen consumption",             "#428bca"        ]
+        [
+            "time_of_maximum_wind",
+            "#000000"
+        ],
+        [
+            "ocean_sigma/general_coordinate",
+            "#000000"
+        ],
+        [
+            "radiation_stress_gradient_y",
+            "#000000"
+        ],
+        [
+            "radiation_stress_gradient_x",
+            "#000000"
+        ],
+        [
+            "pressure_gradient_x",
+            "#000000"
+        ],
+        [
+            "water_surface_height_above_reference_datum",
+            "#d9534f"
+        ],
+        [
+            "maximum_sea_surface_wave_period_at_variance_spectral_density_maximum",
+            "#5cb85c"
+        ],
+        [
+            "ocean_s_coordinate_g2",
+            "#000000"
+        ],
+        [
+            "sea_surface_wave_period_at_variance_spectral_density_maximum",
+            "#5cb85c"
+        ],
+        [
+            "sea_surface_wave_significant_height",
+            "#5cb85c"
+        ],
+        [
+            "mass_concentration_of_oxygen_in_sea_water",
+            "#428bca"
+        ],
+        [
+            "wind_speed_y",
+            "#ecc376"
+        ],
+        [
+            "wind_speed_x",
+            "#ecc376"
+        ],
+        [
+            "sea_floor_depth_below_geoid",
+            "#d9534f"
+        ],
+        [
+            "maximum_radiation_stress",
+            "#000000"
+        ],
+        [
+            "eastward_wind",
+            "#ecc376"
+        ],
+        [
+            "significant_wave_height",
+            "#5cb85c"
+        ],
+        [
+            "sea_surface_wave_to_direction",
+            "#5cb85c"
+        ],
+        [
+            "maximum_wind",
+            "#ecc376"
+        ],
+        [
+            "maximum_water_velocity",
+            "#d9534f"
+        ],
+        [
+            "dissolve oxygen",
+            "#428bca"
+        ],
+        [
+            "minimum_air_pressure_at_sea_level",
+            "#ecc376"
+        ],
+        [
+            "air_pressure_at_sea_level",
+            "#ecc376"
+        ],
+        [
+            "time_of_maximum_sea_surface_height_above_geoid",
+            "#000000"
+        ],
+        [
+            "peak_period",
+            "#5cb85c"
+        ],
+        [
+            "sea_water_salinity",
+            "#428bca"
+        ],
+        [
+            "eastward_sea_water_velocity",
+            "#d9534f"
+        ],
+        [
+            "latitude",
+            "#000000"
+        ],
+        [
+            "sediment oxygen sonsumption",
+            "#428bca"
+        ],
+        [
+            "sea_surface_wave_mean_period_from_variance_spectral_density_inverse_frequency_moment",
+            "#5cb85c"
+        ],
+        [
+            "depth below geoid",
+            "#d9534f"
+        ],
+        [
+            "time_of_maximum_radiation_stress",
+            "#000000"
+        ],
+        [
+            "pressure_gradient_y",
+            "#000000"
+        ],
+        [
+            "northward_wind",
+            "#ecc376"
+        ],
+        [
+            "northward_water_velocity",
+            "#d9534f"
+        ],
+        [
+            "sea_water_potential_temperature",
+            "#428bca"
+        ],
+        [
+            "time",
+            "#000000"
+        ],
+        [
+            "mesh_topology",
+            "#000000"
+        ],
+        [
+            "sea_surface_wave_mean_period_from_variance_spectral_density_second_frequency_moment",
+            "#5cb85c"
+        ],
+        [
+            "ocean_s_coordinate_g1",
+            "#000000"
+        ],
+        [
+            "ocean_sigma_coordinate",
+            "#000000"
+        ],
+        [
+            "northward_sea_water_velocity",
+            "#d9534f"
+        ],
+        [
+            "face_node_connectivity",
+            "#000000"
+        ],
+        [
+            "Wind Velocity",
+            "#ecc376"
+        ],
+        [
+            "maximum_sea_surface_wave_to_direction",
+            "#5cb85c"
+        ],
+        [
+            "wind_stress_y",
+            "#000000"
+        ],
+        [
+            "wind_stress_x",
+            "#000000"
+        ],
+        [
+            "eastward_water_velocity",
+            "#d9534f"
+        ],
+        [
+            "maximum_sea_surface_wave_significant_height",
+            "#5cb85c"
+        ],
+        [
+            "time_of_maximum_water_velocity",
+            "#000000"
+        ],
+        [
+            "wave_direction",
+            "#5cb85c"
+        ],
+        [
+            "sea_surface_elevation",
+            "#d9534f"
+        ],
+        [
+            "maximum_sea_surface_height_above_geoid",
+            "#d9534f"
+        ],
+        [
+            "depth_below_geoid",
+            "#d9534f"
+        ],
+        [
+            "longitude",
+            "#000000"
+        ],
+        [
+            "time_of_minimum_air_pressure_at_sea_level",
+            "#000000"
+        ],
+        [
+            "mean_period",
+            "#5cb85c"
+        ],
+        [
+            "sea_surface_height_above_geoid",
+            "#d9534f"
+        ],
+        [
+            "sea_surface_temperature",
+            "#428bca"
+        ],
+        [
+            "maximum_sea_surface_wave_mean_period_from_variance_spectral_density_inverse_frequency_moment",
+            "#5cb85c"
+        ],
+        [
+            "sea_surface_salinity",
+            "#428bca"
+        ],
+        [
+            "maximum_sea_surface_wave_mean_period_from_variance_spectral_density_second_frequency_moment",
+            "#5cb85c"
+        ],
+        [
+            "sea_water_temperature",
+            "#428bca"
+        ],
+        [
+            "net water column oxygen consumption",
+            "#428bca"
+        ]
     ]
 }

--- a/views/comt/dataset.jade
+++ b/views/comt/dataset.jade
@@ -1,41 +1,41 @@
 extends ../layout
 
 block body
-    div#main-container.container.comt-dataset
-      div.row
-        ol.breadcrumb
-          li
-            a(href='/comt')= 'Coastal and Ocean Modeling Testbed'
-          li
-            a(href='/comt/projects/' + title_key + '#sub-project-descriptions')= project.title
-          li.active
-            !{subProjectTitle}
-      div.row
-        h2.text-center= dataset.title
-        p.text-center= dataset.description
-        div.media
-          div.media-left
-            img(class='media-object thumbnail', src=dataset.thumbnail)
-          div.media-body
-            dl.dl-horizontal
-              if dataset.temporal !== null
-                dt Date Range
-                - var min = new Date(dataset.temporal.substr(0, dataset.temporal.indexOf('/'))).toUTCString().substr(4, 12)
-                - var max = new Date(dataset.temporal.substr(dataset.temporal.lastIndexOf('/') - 19, 19)).toUTCString().substr(4, 12)
-                dd!= min + ' &ndash; ' + max
-              if dataset.spatial !== null
-                dt Spatial Extent
-                dd= dataset.spatial
-              dt Links
-              dd
-                ul
-                  each distro in dataset.distributions
+  div#main-container.container.comt-dataset
+    div.row
+      ol.breadcrumb
+        li
+          a(href='/comt')= 'Coastal and Ocean Modeling Testbed'
+        li
+          a(href='/comt/projects/' + title_key + '#sub-project-descriptions')= project.title
+        li.active
+          !{subProjectTitle}
+    div.row
+      h2.text-center= dataset.title
+      p.text-center= dataset.description
+      div.media
+        div.media-left
+          img(class='media-object thumbnail', src=dataset.thumbnail)
+        div.media-body
+          dl.dl-horizontal
+            if dataset.temporal !== null
+              dt Date Range
+              - var min = new Date(dataset.temporal.substr(0, dataset.temporal.indexOf('/'))).toUTCString().substr(4, 12)
+              - var max = new Date(dataset.temporal.substr(dataset.temporal.lastIndexOf('/') - 19, 19)).toUTCString().substr(4, 12)
+              dd!= min + ' &ndash; ' + max
+            if dataset.spatial !== null
+              dt Spatial Extent
+              dd= dataset.spatial
+            dt Links
+            dd
+              ul
+                each distro in dataset.distributions
+                  li
+                    a(href=distro.downloadURL, target='_blank')= distro.description
+            dt Available Variables
+            dd
+              ul
+                each variable in dataset.variablesMeasured
+                  if typeof variable !== 'string'
                     li
-                      a(href=distro.downloadURL, target='_blank')= distro.description
-              dt Available Variables
-              dd
-                ul
-                  each variable in dataset.variablesMeasured
-                    if typeof variable !== 'string'
-                      li
-                        span.badge(style='background-color:' + variable[1])= variable[0]
+                      span.badge(style='background-color:' + variable[1])= variable[0]


### PR DESCRIPTION
This commit cleans up some code. Fixes #96. Uses arrow functions for
callbacks. The commit refactors the usage for the pg-promise API to use
`any` instead of `many` and uses the regular query instead of
`ParameterizedQuery`.

The commit also cleans up some usage and replaces uses of `every` with a
for-loop or `find` where appropriate.
