### PR TITLE
Add support for dark theme support for component-library,  

### DIFF
--- a/.github/workflows/deploy-component-library.yml
+++ b/.github/workflows/deploy-component-library.yml
@@ -2,6 +2,15 @@ name: Deploy Component Library
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment target'
+        type: choice
+        required: true
+        default: 'dev'
+        options:
+          - dev
+          - production
 
 jobs:
   deploy:
@@ -28,15 +37,26 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1 
 
+      - name: Set bundle filename for environment
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            echo "BUNDLE_FILENAME=ioos-ui-components.min.js" >> "$GITHUB_ENV"
+          else
+            echo "BUNDLE_FILENAME=ioos-ui-components-dev.min.js" >> "$GITHUB_ENV"
+          fi
+
       - name: Upload files to S3
         run: |
-          aws s3 cp static/ioos-ui-components.min.js s3://ioos-ui-components/ioos-ui-components.min.js
-          aws s3 cp component-library/headerMenuConfig.json s3://ioos-ui-components/headerMenuConfig.json
+          aws s3 cp static/ioos-ui-components.min.js "s3://ioos-ui-components/${BUNDLE_FILENAME}"
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            aws s3 cp component-library/headerMenuConfig.json s3://ioos-ui-components/headerMenuConfig.json
+          fi
 
-      - name: Invalidate CloudFront cache for ioos-ui-components.min.js
+      - name: Invalidate CloudFront cache for component bundle
         run: |
-          aws cloudfront create-invalidation --distribution-id E2206S5B6APN8V --paths "/ioos-ui-components.min.js"
+          aws cloudfront create-invalidation --distribution-id E2206S5B6APN8V --paths "/${BUNDLE_FILENAME}"
 
       - name: Invalidate CloudFront cache for headerMenuConfig.json
+        if: inputs.environment == 'production'
         run: |
           aws cloudfront create-invalidation --distribution-id E2206S5B6APN8V --paths "/headerMenuConfig.json"

--- a/component-library/README.md
+++ b/component-library/README.md
@@ -71,6 +71,21 @@ The `variant` attribute selects the header layout:
 
 > Note: `ioos-banner="off"` is a deprecated alias for `variant="no-banner"` and is kept for backward compatibility. It is ignored when a `variant` is set.
 
+### Theme (`theme`)
+
+The `theme` attribute controls the banner color scheme:
+
+```html
+<ioos-header></ioos-header>
+<ioos-header theme="light"></ioos-header>
+<ioos-header theme="dark"></ioos-header>
+```
+
+| Value | Behavior |
+|-------|----------|
+| *(absent or `"light"`)* | Light banner (default) |
+| `"dark"` | Dark banner background |
+
 #### Visual comparison
 
 **Default:**

--- a/component-library/README.md
+++ b/component-library/README.md
@@ -79,12 +79,23 @@ The `theme` attribute controls the banner color scheme:
 <ioos-header></ioos-header>
 <ioos-header theme="light"></ioos-header>
 <ioos-header theme="dark"></ioos-header>
+<ioos-header theme="auto"></ioos-header>
 ```
 
 | Value | Behavior |
 |-------|----------|
 | *(absent or `"light"`)* | Light banner (default) |
 | `"dark"` | Dark banner background |
+| `"auto"` | **Experimental / limited support.** Detects the host page's theme and live-updates when it changes. See below. |
+
+#### `theme="auto"` (experimental, limited support)
+
+`theme="auto"` currently only detects:
+
+1. `data-theme="light|dark"` on the `<html>` element
+2. The OS/browser level `prefers-color-scheme` media query, as a fallback
+
+Other conventions (e.g. Tailwind's `<html class="dark">`) are **not** detected yet. More detection strategies will be added as neeeded; if your site uses a different convention, please open an issue.
 
 #### Visual comparison
 

--- a/component-library/README.md
+++ b/component-library/README.md
@@ -22,11 +22,11 @@ To use these components in your project:
 <script src="https://dgd6r9iiqa8y9.cloudfront.net/ioos-ui-components.min.js">
 ```
 
-2. Add the header and footer containers to your HTML:
+2. Add the header and footer custom elements to your HTML:
 ```html
-<div id="ioos-header"></div>
+<ioos-header></ioos-header>
 <!-- Your content here -->
-<div id="ioos-footer"></div>
+<ioos-footer></ioos-footer>
 ```
 
 ### Customizing the Menu

--- a/component-library/index.html
+++ b/component-library/index.html
@@ -33,10 +33,18 @@
             Overrides the default menu items with a custom JSON configuration.
             See README.md for the expected JSON format.
 
+        theme="light" (or omitted)
+            Light banner (default).
+            Example: <ioos-header theme="light"></ioos-header>
+
+        theme="dark"
+            Dark banner background.
+            Example: <ioos-header theme="dark"></ioos-header>
+
         ioos-banner="off"
             Deprecated alias for variant="no-banner". Ignored when a variant is set.
     -->
-    <ioos-header></ioos-header>
+    <ioos-header  theme="dark"></ioos-header>
 
 
     <div style="height: 1500px;">

--- a/component-library/index.html
+++ b/component-library/index.html
@@ -41,16 +41,21 @@
             Dark banner background.
             Example: <ioos-header theme="dark"></ioos-header>
 
+        theme="auto"
+            EXPERIMENTAL, LIMITED SUPPORT.
+            Currently only detects <html data-theme="light|dark">,
+            Falling back to the OS/browser prefers-color-scheme.
+            Example: <ioos-header theme="auto"></ioos-header>
+
         ioos-banner="off"
             Deprecated alias for variant="no-banner". Ignored when a variant is set.
     -->
-    <ioos-header  theme="dark"></ioos-header>
+    <ioos-header theme="auto"></ioos-header>
 
 
     <div style="height: 1500px;">
         <!-- Content goes here -->
     </div>
-
 
     <ioos-footer></ioos-footer>
 </body>

--- a/component-library/src/header.css
+++ b/component-library/src/header.css
@@ -9,11 +9,19 @@
     width: 100%;
 }
 
+/* Dark theme: sets the banner background dark. Light leaves --banner-bg unset
+   so the fallbacks apply. The dark-mode emblem image (swapped in header.js) is
+   light artwork designed for this dark background. */
+header[data-theme="dark"] {
+    --banner-bg: #021a47;
+}
+
 .ioos-top-header {
     text-align: center;
     display: block;
     height: 55px;
     width: 100%;
+    background: var(--banner-bg, transparent);
 }
 
 .ioos-top-header img {
@@ -109,7 +117,7 @@
     header.compact .ioos-top-header {
         position: relative;
         z-index: 999999;
-        background: #fff;
+        background: var(--banner-bg, #fff);
         display: flex;
         align-items: center;
         justify-content: center;

--- a/component-library/src/header.js
+++ b/component-library/src/header.js
@@ -10,6 +10,7 @@ class HeaderComponent extends HTMLElement {
         this.handleShadowClick = this.handleShadowClick.bind(this);
         this.handleDocumentClick = this.handleDocumentClick.bind(this);
         this.handleTogglerClick = this.handleTogglerClick.bind(this);
+        this.applyTheme = this.applyTheme.bind(this);
         this.render();
     }
 
@@ -56,17 +57,47 @@ class HeaderComponent extends HTMLElement {
         return 'default';
     }
 
-    // Resolves the effective theme: 'light' (default) or 'dark'.
+    // Resolves the effective theme: 'light' (default), 'dark', or detected via 'auto'.
+    //
+    // EXPERIMENTAL — theme="auto" has LIMITED SUPPORT. It currently only detects:
+    //   1. <html data-theme="light|dark">
+    //   2. OS-level prefers-color-scheme, as a fallback when the page sets no data-theme
+    // add new detection strategies here as sites need them.
     get theme() {
-        return this.getAttribute('theme') === 'dark' ? 'dark' : 'light';
+        const attr = this.getAttribute('theme');
+        if (attr === 'dark') return 'dark';
+        if (attr === 'auto') {
+            const pageTheme = document.documentElement.getAttribute('data-theme');
+            if (pageTheme === 'dark') return 'dark';
+            if (pageTheme === 'light') return 'light';
+            return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        return 'light';
+    }
+
+    getEmblemSrc() {
+        return this.theme === 'dark'
+            ? 'https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem-dark.png'
+            : 'https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem.png';
+    }
+
+    // Targeted theme update: re-stamps data-theme and swaps the emblem image
+    // without re-rendering the whole shadow DOM (which would close open menus
+    // and orphan the listeners attached in connectedCallback).
+    applyTheme() {
+        const header = this.shadowRoot.querySelector('header');
+        if (!header) return;
+        header.setAttribute('data-theme', this.theme);
+        const emblem = header.querySelector('.ioos-top-header img');
+        if (emblem) {
+            emblem.src = this.getEmblemSrc();
+        }
     }
 
     render() {
         const variant = this.variant;
         const isCompact = variant === 'compact';
-        const emblemSrc = this.theme === 'dark'
-            ? 'https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem-dark.png'
-            : 'https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem.png';
+        const emblemSrc = this.getEmblemSrc();
         const bannerHtml = variant !== 'no-banner' ? `
                 <div class="ioos-top-header">
                     <img src="${emblemSrc}" class="img-fluid" />
@@ -116,6 +147,16 @@ class HeaderComponent extends HTMLElement {
                 this.handleBannerClick = this.handleBannerClick.bind(this);
                 banner.addEventListener('click', this.handleBannerClick);
             }
+        }
+
+        if (this.getAttribute('theme') === 'auto') {
+            this.themeObserver = new MutationObserver(() => this.applyTheme());
+            this.themeObserver.observe(document.documentElement, {
+                attributes: true,
+                attributeFilter: ['data-theme'],
+            });
+            this.prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+            this.prefersDark.addEventListener('change', this.applyTheme);
         }
 
         setTimeout(() => {
@@ -174,6 +215,14 @@ class HeaderComponent extends HTMLElement {
         const toggler = this.shadowRoot.querySelector('.navbar-toggler');
         if (toggler) {
             toggler.removeEventListener('click', this.handleTogglerClick);
+        }
+        if (this.themeObserver) {
+            this.themeObserver.disconnect();
+            this.themeObserver = null;
+        }
+        if (this.prefersDark) {
+            this.prefersDark.removeEventListener('change', this.applyTheme);
+            this.prefersDark = null;
         }
     }
 

--- a/component-library/src/header.js
+++ b/component-library/src/header.js
@@ -14,7 +14,7 @@ class HeaderComponent extends HTMLElement {
     }
 
     static get observedAttributes() {
-        return ['menu-config', 'variant'];
+        return ['menu-config', 'variant', 'theme'];
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
@@ -27,6 +27,9 @@ class HeaderComponent extends HTMLElement {
             }
         }
         if (name === 'variant') {
+            this.render();
+        }
+        if (name === 'theme') {
             this.render();
         }
     }
@@ -53,19 +56,27 @@ class HeaderComponent extends HTMLElement {
         return 'default';
     }
 
+    // Resolves the effective theme: 'light' (default) or 'dark'.
+    get theme() {
+        return this.getAttribute('theme') === 'dark' ? 'dark' : 'light';
+    }
+
     render() {
         const variant = this.variant;
         const isCompact = variant === 'compact';
+        const emblemSrc = this.theme === 'dark'
+            ? 'https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem-dark.png'
+            : 'https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem.png';
         const bannerHtml = variant !== 'no-banner' ? `
                 <div class="ioos-top-header">
-                    <img src="https://dgd6r9iiqa8y9.cloudfront.net/images/ioos-emblem.png" class="img-fluid" />
+                    <img src="${emblemSrc}" class="img-fluid" />
                     ${isCompact ? '<span class="compact-caret"></span>' : ''}
                 </div>` : '';
         const headerClass = isCompact ? ' class="compact"' : '';
         
         this.shadowRoot.innerHTML = `
             <style>${bootstrapStyles} ${headerStyles}</style>
-            <header${headerClass}>
+            <header${headerClass} data-theme="${this.theme}">
                 ${bannerHtml}
                 <nav class="navbar navbar-expand-lg">
                     <div class="container-fluid">


### PR DESCRIPTION
- Adds dark theme support
- Adds an experimental `theme="auto"` option to `<ioos-header>` that detects the host
  page's theme from `<html data-theme="light|dark">` to support https://github.com/ioos/ioos_code_lab/pull/333 
- Add GHA dev/production deploy targets for component-library. 